### PR TITLE
Fixed issue where itemprop content is ignored

### DIFF
--- a/src/MicrodataPhpDOMElement.php
+++ b/src/MicrodataPhpDOMElement.php
@@ -145,7 +145,11 @@ class MicrodataPhpDOMElement extends \DOMElement {
         if (!empty($datetime))
           return $datetime;
       default:
-        return $this->textContent;
+        if ($this->getAttribute('content')) {
+          return $this->getAttribute('content');
+        } else {
+          return $this->textContent;
+        }
     }
   }
 

--- a/tests/data/recipe.html
+++ b/tests/data/recipe.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>recipe test</title>
+</head>
+<body>
+<div itemscope itemtype="http://schema.org/Recipe">
+    <span itemprop="name">Mom's World Famous Banana Bread</span>
+    By <span itemprop="author">John Smith</span>,
+    <meta itemprop="datePublished" content="2009-05-08">
+    May 8, 2009
+    <img itemprop="image" src="bananabread.jpg"
+            alt="Banana bread on a plate"/>
+  <span itemprop="description">This classic banana bread recipe comes
+  from my mom -- the walnuts add a nice texture and flavor to the banana
+  bread.</span>
+    Prep Time:
+    <meta itemprop="prepTime" content="PT15M">
+    15 minutes
+    Cook time:
+    <meta itemprop="cookTime" content="PT1H">
+    1 hour
+    Yield: <span itemprop="recipeYield">1 loaf</span>
+
+    <div itemprop="nutrition"
+            itemscope itemtype="http://schema.org/NutritionInformation">
+        Nutrition facts:
+        <span itemprop="calories">240 calories</span>,
+        <span itemprop="fatContent">9 grams fat</span>
+    </div>
+    Ingredients:
+    - <span itemprop="recipeIngredient">3 or 4 ripe bananas, smashed</span>
+    - <span itemprop="recipeIngredient">1 egg</span>
+    - <span itemprop="recipeIngredient">3/4 cup of sugar</span>
+    ...
+    Instructions:
+  <span itemprop="recipeInstructions">
+  Preheat the oven to 350 degrees. Mix in the ingredients in a bowl. Add
+  the flour last. Pour the mixture into a loaf pan and bake for one hour.
+  </span>
+    140 comments:
+    <meta itemprop="interactionCount" content="UserComments:140"/>
+    From Janel, May 5 -- thank you, great recipe!
+    ...
+</div>
+</body>
+</html>

--- a/tests/data/recipeItempropContent.html
+++ b/tests/data/recipeItempropContent.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>recipe itemprop content</title>
+</head>
+<body>
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>recipe test</title>
+</head>
+<body>
+<div itemscope itemtype="http://schema.org/Recipe">
+    <span itemprop="name">Mom's World Famous Banana Bread</span>
+    By <span itemprop="author">John Smith</span>,
+    <meta itemprop="datePublished" content="2009-05-08">
+    May 8, 2009
+    <img itemprop="image" src="bananabread.jpg"
+            alt="Banana bread on a plate"/>
+  <span itemprop="description">This classic banana bread recipe comes
+  from my mom -- the walnuts add a nice texture and flavor to the banana
+  bread.</span>
+    Prep Time:
+    <span itemprop="prepTime" content="PT1H10M">1 hour, 10 minutes</span>
+    Cook time:
+    <span itemprop="cookTime" content="PT15M">15 minutes</span>
+
+    Yield: <span itemprop="recipeYield">1 loaf</span>
+
+    <div itemprop="nutrition"
+            itemscope itemtype="http://schema.org/NutritionInformation">
+        Nutrition facts:
+        <span itemprop="calories">240 calories</span>,
+        <span itemprop="fatContent">9 grams fat</span>
+    </div>
+    Ingredients:
+    - <span itemprop="recipeIngredient">3 or 4 ripe bananas, smashed</span>
+    - <span itemprop="recipeIngredient">1 egg</span>
+    - <span itemprop="recipeIngredient">3/4 cup of sugar</span>
+    ...
+    Instructions:
+  <span itemprop="recipeInstructions">
+  Preheat the oven to 350 degrees. Mix in the ingredients in a bowl. Add
+  the flour last. Pour the mixture into a loaf pan and bake for one hour.
+  </span>
+    140 comments:
+    <meta itemprop="interactionCount" content="UserComments:140"/>
+    From Janel, May 5 -- thank you, great recipe!
+    ...
+</div>
+</body>
+</html>
+
+
+</body>
+</html>

--- a/tests/src/MicrodataPhpTest.php
+++ b/tests/src/MicrodataPhpTest.php
@@ -48,6 +48,28 @@ class MicrodataPhpTest extends \PHPUnit_Framework_TestCase {
   }
 
   /**
+   * test recipe prep time
+   */
+  public function testRecipePrepTimeType() {
+    $config = $this->getConfig('recipe.html');
+    $microdata = new MicrodataPhp($config);
+    $data = $microdata->obj();
+
+    $this->assertEquals("PT15M", $data->items[0]->properties['prepTime'][0], 'recipe prepTime should be PT15M');
+  }
+
+  /**
+   * test recipe prep time
+   */
+  public function testRecipePrepTimeContentType() {
+    $config = $this->getConfig('recipeItempropContent.html');
+    $microdata = new MicrodataPhp($config);
+    $data = $microdata->obj();
+
+    $this->assertEquals("PT1H10M", $data->items[0]->properties['prepTime'][0], 'recipe prepTime should be PT1H10M');
+  }
+
+  /**
    * @expectedException \InvalidArgumentException
    */
   public function testConstructorNoUrlOrHtml() {


### PR DESCRIPTION
When parsing recipes, so authors create the prepTime/cookTime in different ways. I've updated the MicrodataPhpDOMElement->itemValue to grab the content attribute if it is present, instead of sending the incorrect element value.

eg. 
<span itemprop="prepTime" content="PT1H10M">1 hour, 10 minutes</span>  should return PT1H10M and not "1 hour, 10 minutes"
